### PR TITLE
Prepare DB in dev container

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -11,3 +11,6 @@ COPY Gemfile Gemfile.lock ./
 RUN gem install bundler -v "${BUNDLER_VERSION}" && bundle install
 
 COPY . .
+
+# Entrypoint prepares the database.
+ENTRYPOINT ["/rails/bin/docker-entrypoint.dev"]

--- a/bin/docker-entrypoint.dev
+++ b/bin/docker-entrypoint.dev
@@ -1,0 +1,6 @@
+#!/bin/bash -e
+
+# If running the rails server then create or migrate existing database
+./bin/rails db:prepare
+
+exec "${@}"


### PR DESCRIPTION
This pull request introduces a small but important change to the `Dockerfile.dev`. It adds an entrypoint script to prepare the database when the container starts.

* [`Dockerfile.dev`](diffhunk://#diff-86930c95a19b82f7e64a962a0053d44e855824813019b3698eae4917a90cdcacR14-R16): Added an entrypoint (`/rails/bin/docker-entrypoint.dev`) to ensure the database is prepared during container startup.