### PR TITLE
Add rostering

### DIFF
--- a/app/controllers/studios_controller.rb
+++ b/app/controllers/studios_controller.rb
@@ -41,6 +41,34 @@ class StudiosController < ApplicationController
     redirect_to studios_path, notice: "Studio was successfully destroyed."
   end
 
+  def roster
+    @studio = Studio.find(params[:id])
+    @roster = @studio.people.joins(:roles).where(roles: { role: :dancer })
+  end
+
+  def new_dancer
+    @studio = Studio.find(params[:id])
+    @dancer = @studio.people.new
+  end
+
+  def add_dancer
+    @studio = Studio.find(params[:id])
+    @dancer = Person.find_or_initialize_by(first_name: person_params[:first_name], last_name: person_params[:last_name])
+
+    if @dancer.new_record?
+      @dancer.assign_attributes(person_params)
+      if !@dancer.save
+        return render :new_dancer, status: :unprocessable_entity
+      end
+    end
+
+    if @studio.add_dancer(@dancer)
+      redirect_to roster_studio_path(@studio), notice: "Dancer was successfully added."
+    else
+      render :new_dancer, status: :unprocessable_entity
+    end
+  end
+
   private
 
   def set_studio
@@ -49,5 +77,9 @@ class StudiosController < ApplicationController
 
   def studio_params
     params.expect(studio: [ :name, :address_line1, :address_line2, :city, :state, :zip_code ])
+  end
+
+  def person_params
+    params.expect(person: [ :first_name, :last_name ])
   end
 end

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -1,0 +1,7 @@
+class Organization < ApplicationRecord
+  has_many :roles, dependent: :destroy
+  has_many :people, through: :roles
+
+  validates :type, :name, :address_line1, :city, :state, :zip_code, presence: true
+  validates :name, uniqueness: { scope: [ :city, :state ], case_sensitive: false, message: "should be unique within the same city and state" }
+end

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -1,0 +1,10 @@
+class Person < ApplicationRecord
+  has_many :roles, dependent: :destroy
+  has_many :organizations, through: :roles
+
+  validates :first_name, :last_name, presence: true
+
+  def full_name
+    "#{first_name} #{last_name}"
+  end
+end

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -1,0 +1,17 @@
+class Role < ApplicationRecord
+  belongs_to :person
+  belongs_to :organization
+
+  enum :role, {
+    owner: 0,
+    admin: 1,
+    staff: 2,
+    instructor: 3,
+    choreographer: 4,
+    parent: 5,
+    dancer: 6
+  }
+
+  validates :role, presence: true
+  validates :person, uniqueness: { scope: [ :organization, :role ] }
+end

--- a/app/models/studio.rb
+++ b/app/models/studio.rb
@@ -1,7 +1,21 @@
-class Studio < ApplicationRecord
-  validates :name, presence: true, uniqueness: true
-  validates :address_line1, presence: true
-  validates :city, presence: true
-  validates :state, presence: true
-  validates :zip_code, presence: true
+class Studio < Organization
+  def add_dancer(person)
+    # Check if the person is already a dancer in this studio
+    if person.roles.where(organization_id: self.id, role: :dancer).exists?
+      errors.add(:base, "Person is already a dancer in this studio.")
+      return false
+    end
+
+    person.roles.create(role: :dancer, organization: self)
+  end
+
+  def add_owner(person)
+    # Check if the person is already an owner of this studio
+    if person.roles.where(organization_id: self.id, role: :owner).exists?
+      errors.add(:base, "Person is already an owner of this studio.")
+      return false
+    end
+
+    person.roles.create(role: :owner, organization: self)
+  end
 end

--- a/app/views/studios/_dancer_form.html.erb
+++ b/app/views/studios/_dancer_form.html.erb
@@ -1,0 +1,16 @@
+<%= form_with model: @dancer, url:add_dancer_studio_path,  class: "space-y-4" do |form| %>
+  <div class="form-control">
+    <%= form.label :first_name, class: "label" %>
+    <%= form.text_field :first_name, class: "input input-bordered w-full" %>
+  </div>
+
+  <div class="form-control">
+    <%= form.label :last_name, class: "label" %>
+    <%= form.text_field :last_name, class: "input input-bordered w-full" %>
+  </div>
+
+  <div class="flex gap-2 mt-4">
+    <%= form.submit "Save", class: "btn btn-primary w-full sm:w-auto" %>
+    <%= link_to "Cancel", studios_path, class: "btn btn-ghost" %>
+  </div>
+<% end %>

--- a/app/views/studios/_dancer_form.html.erb
+++ b/app/views/studios/_dancer_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_with model: @dancer, url:add_dancer_studio_path,  class: "space-y-4" do |form| %>
+<%= form_with model: @dancer, url: add_dancer_studio_path, class: "space-y-4" do |form| %>
   <div class="form-control">
     <%= form.label :first_name, class: "label" %>
     <%= form.text_field :first_name, class: "input input-bordered w-full" %>

--- a/app/views/studios/index.html.erb
+++ b/app/views/studios/index.html.erb
@@ -1,4 +1,4 @@
-<h1 class="text-2xl font-bold mb-4">Studios</h1>
+<h1 class="text-2xl font-bold mb-6">Studios</h1>
 
 <% if authenticated? %>
   <div class="mb-4 flex justify-end">

--- a/app/views/studios/new_dancer.html.erb
+++ b/app/views/studios/new_dancer.html.erb
@@ -1,0 +1,3 @@
+<h1 class="text-2xl font-bold mb-6">New Dancer</h1>
+
+<%= render "dancer_form", studio: @studio, dancer: @dancer %>

--- a/app/views/studios/roster.html.erb
+++ b/app/views/studios/roster.html.erb
@@ -1,0 +1,31 @@
+<h1 class="text-2xl font-bold mb-6"><%= @studio.name %> - Roster</h1>
+
+<% if @roster.any? %>
+  <ul class="list bg-base-100 rounded-box shadow-md">
+
+    <li class="p-4 pb-2 text-xs opacity-60 tracking-wide">Dancers</li>
+
+    <% @roster.each do |person| %>
+      <li class="list-row">
+        <div>
+          <div><%= person.full_name %></div>
+          <div class="text-xs uppercase font-semibold opacity-60">Preteen</div>
+        </div>
+      </li>
+    <% end %>
+  </ul>
+<% else %>
+  <p class="mt-6 text-gray-500">No dancers found.</p>
+<% end %>
+
+<div class="flex justify-between items-center mb-4">
+  <div>
+    <%= link_to "Back", studio_path(@studio), class: "btn btn-ghost mr-2" %>
+  </div>
+
+  <% if authenticated? %>
+    <div class="flex gap-2">
+      <%= link_to "Add Dancer", new_dancer_studio_path(@studio), class: "btn btn-primary" %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/studios/show.html.erb
+++ b/app/views/studios/show.html.erb
@@ -1,5 +1,24 @@
 <h1 class="text-2xl font-bold mb-6"><%= @studio.name %></h1>
 
+<div class="bg-base-100 rounded-box shadow-md p-6 mb-6">
+  <div class="mb-2 text-lg font-semibold">Studio Details</div>
+  <div>
+    <span class="font-bold">Address:</span>
+    <span>
+      <%= @studio.address_line1 %>
+      <% if @studio.address_line2.present? %>
+        , <%= @studio.address_line2 %>
+      <% end %>
+      <br>
+      <%= @studio.city %>, <%= @studio.state %> <%= @studio.zip_code %>
+    </span>
+  </div>
+</div>
+
+<div class="mb-6">
+  <%= link_to "View Roster", roster_studio_path(@studio), class: "btn btn-outline btn-primary" %>
+</div>
+
 <div class="flex justify-between items-center">
   <div>
     <%= link_to "Back", studios_path, class: "btn btn-ghost mr-2" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,7 +14,13 @@ Rails.application.routes.draw do
   resources :passwords, param: :token
 
   # Studio routes
-  resources :studios
+  resources :studios do
+    member do
+      get "roster"
+      get "new_dancer"
+      post "add_dancer"
+    end
+  end
 
   # Defines the root path route ("/")
   root "studios#index"

--- a/db/migrate/20250701212713_create_organizations.rb
+++ b/db/migrate/20250701212713_create_organizations.rb
@@ -1,0 +1,17 @@
+class CreateOrganizations < ActiveRecord::Migration[8.0]
+  def change
+    create_table :organizations do |t|
+      t.string :type, null: false
+      t.string :name, null: false
+      t.string :address_line1, null: false
+      t.string :address_line2
+      t.string :city, null: false
+      t.string :state, null: false
+      t.string :zip_code, null: false
+
+      t.timestamps
+    end
+    add_index :organizations, :type
+    add_index :organizations, [ :name, :city, :state ], unique: true
+  end
+end

--- a/db/migrate/20250701213510_drop_studios_table.rb
+++ b/db/migrate/20250701213510_drop_studios_table.rb
@@ -1,0 +1,9 @@
+class DropStudiosTable < ActiveRecord::Migration[8.0]
+  def up
+    drop_table :studios
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration, "This migration cannot be reverted because it destroys data."
+  end
+end

--- a/db/migrate/20250701231410_create_people.rb
+++ b/db/migrate/20250701231410_create_people.rb
@@ -1,0 +1,10 @@
+class CreatePeople < ActiveRecord::Migration[8.0]
+  def change
+    create_table :people do |t|
+      t.string :first_name, null: false
+      t.string :last_name, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20250711191408_create_roles.rb
+++ b/db/migrate/20250711191408_create_roles.rb
@@ -1,0 +1,12 @@
+class CreateRoles < ActiveRecord::Migration[8.0]
+  def change
+    create_table :roles do |t|
+      t.references :person, null: false, foreign_key: true
+      t.references :organization, null: false, foreign_key: true
+      t.integer :role
+
+      t.timestamps
+    end
+    add_index :roles, [ :person_id, :organization_id, :role ], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,41 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_06_08_235909) do
+ActiveRecord::Schema[8.0].define(version: 2025_07_11_191408) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
+
+  create_table "organizations", force: :cascade do |t|
+    t.string "type", null: false
+    t.string "name", null: false
+    t.string "address_line1", null: false
+    t.string "address_line2"
+    t.string "city", null: false
+    t.string "state", null: false
+    t.string "zip_code", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["name", "city", "state"], name: "index_organizations_on_name_and_city_and_state", unique: true
+    t.index ["type"], name: "index_organizations_on_type"
+  end
+
+  create_table "people", force: :cascade do |t|
+    t.string "first_name", null: false
+    t.string "last_name", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "roles", force: :cascade do |t|
+    t.bigint "person_id", null: false
+    t.bigint "organization_id", null: false
+    t.integer "role"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["organization_id"], name: "index_roles_on_organization_id"
+    t.index ["person_id", "organization_id", "role"], name: "index_roles_on_person_id_and_organization_id_and_role", unique: true
+    t.index ["person_id"], name: "index_roles_on_person_id"
+  end
 
   create_table "sessions", force: :cascade do |t|
     t.bigint "user_id", null: false
@@ -23,18 +55,6 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_08_235909) do
     t.index ["user_id"], name: "index_sessions_on_user_id"
   end
 
-  create_table "studios", force: :cascade do |t|
-    t.string "name", null: false
-    t.string "address_line1", null: false
-    t.string "address_line2"
-    t.string "city", null: false
-    t.string "state", null: false
-    t.string "zip_code", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["name"], name: "index_studios_on_name", unique: true
-  end
-
   create_table "users", force: :cascade do |t|
     t.string "email_address", null: false
     t.string "password_digest", null: false
@@ -43,5 +63,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_08_235909) do
     t.index ["email_address"], name: "index_users_on_email_address", unique: true
   end
 
+  add_foreign_key "roles", "organizations"
+  add_foreign_key "roles", "people"
   add_foreign_key "sessions", "users"
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -13,7 +13,7 @@ User.find_or_create_by!(
   password_digest: BCrypt::Password.create("gNX$KqB3$hcLcYgN"),
 )
 
-Studio.find_or_create_by!(
+avanti = Studio.find_or_create_by!(
   name: "Avanti Dance Company",
   address_line1: "151 Kalmus Dr",
   address_line2: "Ste J7",
@@ -21,3 +21,59 @@ Studio.find_or_create_by!(
   state: "CA",
   zip_code: "92626"
 )
+
+people_data = [
+  {
+    first_name: "Taryn",
+    last_name: "Chavez",
+    roles: [ { organization: avanti, role: :owner } ]
+  },
+  {
+    first_name: "Ailah",
+    last_name: "Medina",
+    roles: [ { organization: avanti, role: :dancer } ]
+    # add more associations here as needed
+  },
+  {
+    first_name: "Aurelia",
+    last_name: "Coker",
+    roles: [ { organization: avanti, role: :dancer } ]
+  },
+  {
+    first_name: "Kylie Sophia",
+    last_name: "Bartolome",
+    roles: [ { organization: avanti, role: :dancer } ]
+  }
+  # ...add more people as needed...
+]
+
+people = {}
+
+people_data.each do |attrs|
+  person = Person.find_or_create_by!(
+    first_name: attrs[:first_name],
+    last_name: attrs[:last_name]
+  )
+  people[person.full_name] = person
+  attrs[:roles].each do |role_attrs|
+    org = role_attrs[:organization]
+    role = role_attrs[:role].to_sym
+
+    case role
+    when :owner
+      org.add_owner(person)
+    when :dancer
+      org.add_dancer(person)
+    else
+      Role.find_or_create_by!(
+        person: person,
+        organization: org,
+        role: role
+      )
+    end
+  end
+  # Add other associations here if needed, using attrs
+end
+
+# Example: Access a person for further associations
+# people["Ailah Medina"].some_other_association.create!(...)

--- a/test/controllers/passwords_controller_test.rb
+++ b/test/controllers/passwords_controller_test.rb
@@ -6,13 +6,14 @@ class PasswordsControllerTest < ActionDispatch::IntegrationTest
   end
 
   # new
-  test "should get new" do
+  test "renders new password form" do
     get new_password_url
+
     assert_response :success
   end
 
   # create
-  test "should send reset instructions if email exists" do
+  test "sends reset instructions when email exists" do
     assert_enqueued_emails 1 do
       post passwords_url, params: { email_address: @user.email_address }
     end
@@ -21,7 +22,7 @@ class PasswordsControllerTest < ActionDispatch::IntegrationTest
     assert_match(/Password reset instructions sent/, flash[:notice])
   end
 
-  test "should not fail if email does not exist" do
+  test "does not fail and redirects when email does not exist" do
     assert_enqueued_emails 0 do
       post passwords_url, params: { email_address: "notfound@example.com" }
     end
@@ -31,45 +32,56 @@ class PasswordsControllerTest < ActionDispatch::IntegrationTest
   end
 
   # edit
-  test "should get edit with valid token" do
+  test "renders edit form with valid token" do
     token = @user.password_reset_token
+
     get edit_password_url(token: token)
+
     assert_response :success
   end
 
-  test "should redirect edit with invalid token" do
+  test "redirects to new with invalid token" do
     get edit_password_url(token: "invalidtoken")
+
     assert_redirected_to new_password_path
     assert_match(/invalid or has expired/i, flash[:alert])
   end
 
   # update
-  test "should update password with valid token and matching passwords" do
+  test "resets password with valid token and matching confirmation" do
     token = @user.password_reset_token
+
     patch password_url(token: token), params: { password: "newpass", password_confirmation: "newpass" }
+
     assert_redirected_to new_session_path
     assert_match(/Password has been reset/, flash[:notice])
 
     @user.reload
+
     assert @user.authenticate("newpass")
   end
 
-  test "should not update password if passwords do not match" do
+  test "does not reset password if confirmation does not match" do
     token = @user.password_reset_token
+
     patch password_url(token: token), params: { password: "newpass", password_confirmation: "wrong" }
+
     assert_redirected_to edit_password_path(token)
     assert_match(/Passwords did not match/, flash[:alert])
 
     @user.reload
+
     assert @user.authenticate("password")
   end
 
-  test "should redirect update with invalid token" do
+  test "redirects to new when updating with invalid token" do
     patch password_url(token: "invalidtoken"), params: { password: "newpass", password_confirmation: "newpass" }
+
     assert_redirected_to new_password_path
     assert_match(/invalid or has expired/i, flash[:alert])
 
     @user.reload
+
     assert @user.authenticate("password")
   end
 end

--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -6,29 +6,32 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
   end
 
   # new
-  test "should get new" do
+  test "renders new session form" do
     get new_session_url
+
     assert_response :success
   end
 
   # create
-  test "should create session with valid credentials" do
+  test "creates session with valid credentials" do
     sign_in_as(@user)
 
     assert_response :redirect
     assert_redirected_to root_url
   end
 
-  test "should not create session with invalid credentials" do
+  test "does not create session with invalid credentials" do
     post session_url, params: { email_address: @user.email_address, password: "wrongpassword" }
+
     assert_redirected_to new_session_url
   end
 
   # destroy
-  test "should destroy session" do
+  test "destroys session" do
     sign_in_as(@user)
 
     delete session_url
+
     assert_response :redirect
     assert_redirected_to new_session_url
   end

--- a/test/controllers/studios_controller_test.rb
+++ b/test/controllers/studios_controller_test.rb
@@ -7,26 +7,29 @@ class StudiosControllerTest < ActionDispatch::IntegrationTest
   end
 
   # index
-  test "should get index" do
+  test "renders index" do
     get studios_url
+
     assert_response :success
   end
 
   # new
-  test "should get new" do
+  test "renders new studio form" do
     sign_in_as(@user)
 
     get new_studio_url
+
     assert_response :success
   end
 
-  test "should redirect new when not signed in" do
+  test "redirects new when not signed in" do
     get new_studio_url
+
     assert_response :redirect
   end
 
   # create
-  test "should create studio" do
+  test "creates studio" do
     sign_in_as(@user)
 
     assert_difference("Studio.count") do
@@ -36,7 +39,7 @@ class StudiosControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to studio_url(Studio.last)
   end
 
-  test "should not create studio with invalid params" do
+  test "does not create studio with invalid params" do
     sign_in_as(@user)
 
     assert_no_difference("Studio.count") do
@@ -46,7 +49,7 @@ class StudiosControllerTest < ActionDispatch::IntegrationTest
     assert_response :unprocessable_entity
   end
 
-  test "should not create studio when not signed in" do
+  test "does not create studio when not signed in" do
     assert_no_difference("Studio.count") do
       post studios_url, params: { studio: attributes_for(:studio) }
     end
@@ -55,74 +58,86 @@ class StudiosControllerTest < ActionDispatch::IntegrationTest
   end
 
   # show
-  test "should show studio" do
+  test "renders studio" do
     get studio_url(@studio)
+
     assert_response :success
   end
 
-  test "should return 404 for show with invalid id" do
+  test "returns 404 for show with invalid id" do
     get studio_url(-1)
+
     assert_response :not_found
   end
 
   # edit
-  test "should get edit" do
+  test "renders edit studio form" do
     sign_in_as(@user)
 
     get edit_studio_url(@studio)
+
     assert_response :success
   end
 
-  test "should redirect edit when not signed in" do
+  test "redirects edit when not signed in" do
     get edit_studio_url(@studio)
+
     assert_response :redirect
   end
 
-  test "should return 404 for edit with invalid id" do
+  test "returns 404 for edit with invalid id" do
     sign_in_as(@user)
 
     get edit_studio_url(-1)
+
     assert_response :not_found
   end
 
   # update
-  test "should update studio" do
+  test "updates studio" do
     sign_in_as(@user)
 
     patch studio_url(@studio), params: { studio: { name: "Updated Studio" } }
+
     assert_redirected_to studio_url(@studio)
 
     @studio.reload
+
     assert_equal "Updated Studio", @studio.name
   end
 
-  test "should not update studio with invalid params" do
+  test "does not update studio with invalid params" do
     sign_in_as(@user)
 
     patch studio_url(@studio), params: { studio: { name: "" } }
+
     assert_response :unprocessable_entity
 
     @studio.reload
+
     assert_not_equal "", @studio.name
   end
 
-  test "should not update studio when not signed in" do
+  test "does not update studio when not signed in" do
     patch studio_url(@studio), params: { studio: { name: "No Auth Update" } }
+
     assert_response :redirect
 
     @studio.reload
+
     assert_not_equal "No Auth Update", @studio.name
   end
 
-  test "should return 404 for update with invalid id" do
+  test "returns 404 for update with invalid id" do
     sign_in_as(@user)
 
     patch studio_url(-1), params: { studio: { name: "Doesn't Matter" } }
+
     assert_response :not_found
   end
 
   # destroy
-  test "should destroy studio" do
+  test "destroys studio" do
     sign_in_as(@user)
 
     assert_difference("Studio.count", -1) do
@@ -132,7 +147,7 @@ class StudiosControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to studios_url
   end
 
-  test "should not destroy studio when not signed in" do
+  test "does not destroy studio when not signed in" do
     assert_no_difference("Studio.count") do
       delete studio_url(@studio)
     end
@@ -140,10 +155,115 @@ class StudiosControllerTest < ActionDispatch::IntegrationTest
     assert_response :redirect
   end
 
-  test "should return 404 for destroy with invalid id" do
+  test "returns 404 for destroy with invalid id" do
     sign_in_as(@user)
 
     delete studio_url(-1)
+
+    assert_response :not_found
+  end
+
+  # roster
+  test "renders roster" do
+    sign_in_as(@user)
+
+    dancer = create(:person)
+    @studio.add_dancer(dancer)
+
+    get roster_studio_url(@studio)
+
+    assert_response :success
+    assert_select "body", /#{dancer.first_name}/
+  end
+
+  test "redirects roster when not signed in" do
+    get roster_studio_url(@studio)
+
+    assert_response :redirect
+  end
+
+  test "returns 404 for roster with invalid id" do
+    sign_in_as(@user)
+
+    get roster_studio_url(-1)
+
+    assert_response :not_found
+  end
+
+  # new_dancer
+  test "renders new dancer form" do
+    sign_in_as(@user)
+
+    get new_dancer_studio_url(@studio)
+
+    assert_response :success
+  end
+
+  test "redirects new dancer when not signed in" do
+    get new_dancer_studio_url(@studio)
+
+    assert_response :redirect
+  end
+
+  test "returns 404 for new dancer with invalid id" do
+    sign_in_as(@user)
+
+    get new_dancer_studio_url(-1)
+
+    assert_response :not_found
+  end
+
+  # add_dancer
+  test "adds dancer and redirects to roster" do
+    sign_in_as(@user)
+
+    dancer_attrs = attributes_for(:person)
+
+    assert_difference("@studio.people.count") do
+      post add_dancer_studio_url(@studio), params: { person: dancer_attrs }
+    end
+
+    assert_redirected_to roster_studio_url(@studio)
+  end
+
+  test "does not add dancer when not signed in" do
+    dancer_attrs = attributes_for(:person)
+
+    assert_no_difference("@studio.people.count") do
+      post add_dancer_studio_url(@studio), params: { person: dancer_attrs }
+    end
+
+    assert_response :redirect
+  end
+
+  test "does not add dancer with invalid params" do
+    sign_in_as(@user)
+
+    assert_no_difference("@studio.people.count") do
+      post add_dancer_studio_url(@studio), params: { person: { first_name: "", last_name: "" } }
+    end
+
+    assert_response :unprocessable_entity
+  end
+
+  test "does not add duplicate dancer" do
+    sign_in_as(@user)
+
+    dancer = create(:person)
+    @studio.add_dancer(dancer)
+
+    assert_no_difference("@studio.people.count") do
+      post add_dancer_studio_url(@studio), params: { person: { first_name: dancer.first_name, last_name: dancer.last_name } }
+    end
+
+    assert_response :unprocessable_entity
+  end
+
+  test "returns 404 for add dancer with invalid id" do
+    sign_in_as(@user)
+
+    post add_dancer_studio_url(-1), params: { person: attributes_for(:person) }
+
     assert_response :not_found
   end
 end

--- a/test/factories/people.rb
+++ b/test/factories/people.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :person do
+    first_name { Faker::Name.first_name }
+    last_name { Faker::Name.last_name }
+  end
+end

--- a/test/factories/roles.rb
+++ b/test/factories/roles.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :role do
+    person
+    association :organization, factory: :studio
+  end
+end

--- a/test/models/person_test.rb
+++ b/test/models/person_test.rb
@@ -1,0 +1,32 @@
+require "test_helper"
+
+class PersonTest < ActiveSupport::TestCase
+  def setup
+    @person = build(:person)
+  end
+
+  test "is valid with all required attributes" do
+    assert @person.valid?
+  end
+
+  test "is invalid without first name" do
+    @person.first_name = nil
+
+    assert_not @person.valid?
+    assert_includes @person.errors[:first_name], "can't be blank"
+  end
+
+  test "is invalid without last name" do
+    @person.last_name = nil
+
+    assert_not @person.valid?
+    assert_includes @person.errors[:last_name], "can't be blank"
+  end
+
+  test "returns full name as first and last name concatenated" do
+    @person.first_name = "Ada"
+    @person.last_name = "Lovelace"
+
+    assert_equal "Ada Lovelace", @person.full_name
+  end
+end

--- a/test/models/role_test.rb
+++ b/test/models/role_test.rb
@@ -1,0 +1,57 @@
+require "test_helper"
+
+class RoleTest < ActiveSupport::TestCase
+  def setup
+    @role = build(:role, :dancer)
+  end
+
+  test "is valid with all required attributes" do
+    assert @role.valid?
+  end
+
+  test "is invalid without person" do
+    @role.person = nil
+
+    assert_not @role.valid?
+    assert_includes @role.errors[:person], "must exist"
+  end
+
+  test "is invalid without organization" do
+    @role.organization = nil
+
+    assert_not @role.valid?
+    assert_includes @role.errors[:organization], "must exist"
+  end
+
+  test "is invalid without role type" do
+    @role.role = nil
+
+    assert_not @role.valid?
+    assert_includes @role.errors[:role], "can't be blank"
+  end
+
+  test "is invalid with duplicate role for person in same organization" do
+    @role.save!
+
+    duplicate = build(:role, person: @role.person, organization: @role.organization, role: @role.role)
+
+    assert_not duplicate.valid?
+    assert_includes duplicate.errors[:person], "has already been taken"
+  end
+
+  test "is valid with unique roles for person in same organization" do
+    @role.save!
+
+    unique_role = build(:role, person: @role.person, organization: @role.organization, role: :admin)
+
+    assert unique_role.valid?
+  end
+
+  test "is valid with same role for person in different organizations" do
+    @role.save!
+
+    different_org_role = build(:role, person: @role.person, organization: create(:studio), role: @role.role)
+
+    assert different_org_role.valid?
+  end
+end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -9,19 +9,21 @@ class UserTest < ActiveSupport::TestCase
     assert @user.valid?
   end
 
-  test "is invalid without an email address" do
+  test "is invalid without email address" do
     @user.email_address = nil
+
     assert_not @user.valid?
     assert_includes @user.errors[:email_address], "can't be blank"
   end
 
-  test "is invalid without a password" do
+  test "is invalid without password" do
     @user.password_digest = nil
+
     assert_not @user.valid?
     assert_includes @user.errors[:password_digest], "can't be blank"
   end
 
-  test "should authenticate with valid password" do
+  test "authenticates with valid password" do
     assert @user.authenticate("password")
   end
 end


### PR DESCRIPTION
This pull request introduces significant changes to the application, focusing on refactoring the `Studio` model into a more general `Organization` model, adding support for managing `People` and `Roles`, and implementing new features for managing dancers in a studio. The changes also include updates to the database schema, views, controllers, and tests to support these enhancements.

### Model and Database Refactor:
* Introduced a new `Organization` model that generalizes the `Studio` model, allowing for more flexible role-based associations. The `Studio` model now inherits from `Organization` (`app/models/organization.rb`, `app/models/studio.rb`, `db/migrate/20250701212713_create_organizations.rb`, `db/migrate/20250701213510_drop_studios_table.rb`, `db/schema.rb`). [[1]](diffhunk://#diff-0ee28d6592941883dd2f0006587a46e2d9e66ef444ab746cbf3db6a778c6fc60R1-R7) [[2]](diffhunk://#diff-f9922cf72205415b7722f75e8a51520eb78198b60104198b1b2b3d11881942c2L1-R20) [[3]](diffhunk://#diff-3eb85bd2c857769c8ab331eae11dc2d5c74de1b7cdcbe29a0942327eac74a14cR1-R17) [[4]](diffhunk://#diff-728373ae5f7ca18d5e117aa20a56c9755d395f06ffbfef916cb5a90a54f352e7R1-R9) [[5]](diffhunk://#diff-cbf8b25d6d853acf58fa9057841f407d29ffe90649c75cf9e3f51b2d6e3aa1d3L13-R18)
* Added `Person` and `Role` models to manage individuals and their roles within organizations. `Role` includes an enum for various roles (e.g., `dancer`, `owner`) and ensures uniqueness of roles per person and organization (`app/models/person.rb`, `app/models/role.rb`, `db/migrate/20250701231410_create_people.rb`, `db/migrate/20250711191408_create_roles.rb`, `db/schema.rb`). [[1]](diffhunk://#diff-afb6f8bc3bae71b75743e00882a060863e2430cbe858ec9014e5956504dfc61cR1-R10) [[2]](diffhunk://#diff-81647a521a55f3b496fdef1a196a4cee6502fa175f158d6eb8db6074c16966bcR1-R17) [[3]](diffhunk://#diff-1e9fba78ecb03c83259570d93b294ba1c5dc4efd95e30020de4f7caea183d28fR1-R10) [[4]](diffhunk://#diff-dc533b3bc7ab0420131951b4f1cef81c3982b1fc6fc7ea05248dc741b1c1588aR1-R12) [[5]](diffhunk://#diff-cbf8b25d6d853acf58fa9057841f407d29ffe90649c75cf9e3f51b2d6e3aa1d3L35-R55)

### Controller Enhancements:
* Added new actions (`roster`, `new_dancer`, `add_dancer`) to `StudiosController` to manage dancers in a studio, including logic for adding dancers and handling validation errors (`app/controllers/studios_controller.rb`). [[1]](diffhunk://#diff-466ad29517468a21546bf1e8f6fd0a53cfcdb4e2b65f7eb30a183af77eca3273R44-R71) [[2]](diffhunk://#diff-466ad29517468a21546bf1e8f6fd0a53cfcdb4e2b65f7eb30a183af77eca3273R81-R84)
* Updated `routes.rb` to include new routes for managing dancers (`config/routes.rb`).

### View Updates:
* Created new views for displaying a studio's roster and adding dancers, including reusable partials for forms (`app/views/studios/roster.html.erb`, `app/views/studios/new_dancer.html.erb`, `app/views/studios/_dancer_form.html.erb`). [[1]](diffhunk://#diff-bc578fd716cf95b85690c8b0d520459325beb62ffddedf4dd0259269f0138981R1-R31) [[2]](diffhunk://#diff-0ea20e2694a231d310669a6996b702e4e77a14fe8633efc319a014600b6ca359R1-R3) [[3]](diffhunk://#diff-a910ceafb3becdda7b48ed5d353ab4df7073bc31f735e1c25b7220a4661a75a0R1-R16)
* Enhanced existing views to include links and buttons for managing dancers (`app/views/studios/show.html.erb`, `app/views/studios/index.html.erb`). [[1]](diffhunk://#diff-1ebceba6529700a115f042198b88d4eff98a50111f1ea30863ab6ba554c630aeR3-R21) [[2]](diffhunk://#diff-9a2d597550ab836ae477e7b91a726814c4607d009762863f4d87935a1eeb4efdL1-R1)

### Seed Data:
* Updated `db/seeds.rb` to populate the database with sample data for `People`, `Roles`, and `Organizations`, including dancers and owners for a sample studio.

### Test Updates:
* Refactored existing tests to improve clarity and added test coverage for new functionality in `StudiosController` and related models (`test/controllers/studios_controller_test.rb`, `test/controllers/passwords_controller_test.rb`, `test/controllers/sessions_controller_test.rb`). [[1]](diffhunk://#diff-b03068af18b18521ebea72fbb4e9bae9e613649e7cf25aa3bf9c3cac1229f27aL10-R32) [[2]](diffhunk://#diff-b03068af18b18521ebea72fbb4e9bae9e613649e7cf25aa3bf9c3cac1229f27aL39-R42) [[3]](diffhunk://#diff-b18721527d46de9b2eb33e182fbe7c7e0fb965c010817b030c047b92c0445c20L9-R16) [[4]](diffhunk://#diff-0ebf4c65ae927de1d02650f4caa7f2810e14eb64201b7570cb30939f0ee38719L9-R34)