### PR TITLE
Refactor `:unprocessable_entity`

### DIFF
--- a/app/controllers/studios_controller.rb
+++ b/app/controllers/studios_controller.rb
@@ -16,7 +16,7 @@ class StudiosController < ApplicationController
     if @studio.save
       redirect_to @studio, notice: "Studio was successfully created."
     else
-      render :new, status: :unprocessable_entity
+      render :new, status: :unprocessable_content
     end
   end
 
@@ -32,7 +32,7 @@ class StudiosController < ApplicationController
     if @studio.update(studio_params)
       redirect_to @studio, notice: "Studio was successfully updated."
     else
-      render :edit, status: :unprocessable_entity
+      render :edit, status: :unprocessable_content
     end
   end
 
@@ -58,14 +58,14 @@ class StudiosController < ApplicationController
     if @dancer.new_record?
       @dancer.assign_attributes(person_params)
       if !@dancer.save
-        return render :new_dancer, status: :unprocessable_entity
+        return render :new_dancer, status: :unprocessable_content
       end
     end
 
     if @studio.add_dancer(@dancer)
       redirect_to roster_studio_path(@studio), notice: "Dancer was successfully added."
     else
-      render :new_dancer, status: :unprocessable_entity
+      render :new_dancer, status: :unprocessable_content
     end
   end
 

--- a/test/controllers/studios_controller_test.rb
+++ b/test/controllers/studios_controller_test.rb
@@ -46,7 +46,7 @@ class StudiosControllerTest < ActionDispatch::IntegrationTest
       post studios_url, params: { studio: { name: "", address_line1: "", city: "", state: "", zip_code: "" } }
     end
 
-    assert_response :unprocessable_entity
+    assert_response :unprocessable_content
   end
 
   test "does not create studio when not signed in" do
@@ -111,7 +111,7 @@ class StudiosControllerTest < ActionDispatch::IntegrationTest
 
     patch studio_url(@studio), params: { studio: { name: "" } }
 
-    assert_response :unprocessable_entity
+    assert_response :unprocessable_content
 
     @studio.reload
 
@@ -243,7 +243,7 @@ class StudiosControllerTest < ActionDispatch::IntegrationTest
       post add_dancer_studio_url(@studio), params: { person: { first_name: "", last_name: "" } }
     end
 
-    assert_response :unprocessable_entity
+    assert_response :unprocessable_content
   end
 
   test "does not add duplicate dancer" do
@@ -256,7 +256,7 @@ class StudiosControllerTest < ActionDispatch::IntegrationTest
       post add_dancer_studio_url(@studio), params: { person: { first_name: dancer.first_name, last_name: dancer.last_name } }
     end
 
-    assert_response :unprocessable_entity
+    assert_response :unprocessable_content
   end
 
   test "returns 404 for add dancer with invalid id" do


### PR DESCRIPTION
This pull request updates the error handling in the `StudiosController` and its associated tests to use the correct HTTP status symbol for unprocessable content. The main change is replacing the deprecated or incorrect `:unprocessable_entity` status with `:unprocessable_content` throughout the controller actions and tests.

Error handling updates:

* Updated the `create`, `update`, and `add_dancer` actions in `StudiosController` to render error responses with `status: :unprocessable_content` instead of `:unprocessable_entity`. [[1]](diffhunk://#diff-466ad29517468a21546bf1e8f6fd0a53cfcdb4e2b65f7eb30a183af77eca3273L19-R19) [[2]](diffhunk://#diff-466ad29517468a21546bf1e8f6fd0a53cfcdb4e2b65f7eb30a183af77eca3273L35-R35) [[3]](diffhunk://#diff-466ad29517468a21546bf1e8f6fd0a53cfcdb4e2b65f7eb30a183af77eca3273L61-R68)

Test updates:

* Modified all relevant assertions in `studios_controller_test.rb` to expect `:unprocessable_content` instead of `:unprocessable_entity` for error cases. [[1]](diffhunk://#diff-b03068af18b18521ebea72fbb4e9bae9e613649e7cf25aa3bf9c3cac1229f27aL49-R49) [[2]](diffhunk://#diff-b03068af18b18521ebea72fbb4e9bae9e613649e7cf25aa3bf9c3cac1229f27aL114-R114) [[3]](diffhunk://#diff-b03068af18b18521ebea72fbb4e9bae9e613649e7cf25aa3bf9c3cac1229f27aL246-R246) [[4]](diffhunk://#diff-b03068af18b18521ebea72fbb4e9bae9e613649e7cf25aa3bf9c3cac1229f27aL259-R259)