### PR TITLE
Add season membership

### DIFF
--- a/app/controllers/seasons_controller.rb
+++ b/app/controllers/seasons_controller.rb
@@ -47,6 +47,22 @@ class SeasonsController < ApplicationController
     redirect_to studio_seasons_path(@season.studio), status: :see_other, notice: "Season was successfully destroyed."
   end
 
+  def select_dancer
+    @season = Season.find(params[:id])
+    @dancers = @season.get_eligible_dancers
+  end
+
+  def add_dancer
+    @season = Season.find(params[:id])
+    @dancer = Person.find(params[:person_id])
+
+    if @season.add_dancer(@dancer)
+      redirect_to season_path(@season), notice: "Dancer was successfully added to the season."
+    else
+      redirect_to select_dancer_season_path(@season), alert: @season.errors.full_messages.to_sentence
+    end
+  end
+
   private
     # Use callbacks to share common setup or constraints between actions.
     def set_season

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -1,6 +1,8 @@
 class Person < ApplicationRecord
   has_many :studio_memberships, dependent: :destroy
   has_many :studios, through: :studio_memberships
+  has_many :season_memberships, dependent: :destroy
+  has_many :seasons, through: :season_memberships
 
   validates :first_name, :last_name, presence: true
 

--- a/app/models/season.rb
+++ b/app/models/season.rb
@@ -1,11 +1,52 @@
 class Season < ApplicationRecord
   belongs_to :studio
 
+  has_many :season_memberships, dependent: :destroy
+  has_many :people, through: :season_memberships
+
   validates :name, :start_year, :end_year, presence: true
   validate :start_year_not_greater_than_end_year
 
   def year
     start_year == end_year ? start_year.to_s : "#{start_year} - #{end_year}"
+  end
+
+  def add_dancer(person)
+    if studio.people.where(id: person.id).exists?
+      if person.season_memberships.where(season_id: self.id, role: :dancer).exists?
+        errors.add(:base, "Person is already a dancer in this season.")
+        return false
+      end
+    else
+      errors.add(:base, "Person must be a member of the studio to be added as a dancer.")
+      return false
+    end
+
+    person.season_memberships.create(role: :dancer, season: self)
+  end
+
+  def get_dancers
+    self.people.where("season_memberships.role = ?", SeasonMembership.roles[:dancer])
+  end
+
+  def get_eligible_dancers
+    self.studio.get_dancers
+        .joins(sprintf("LEFT OUTER JOIN season_memberships ON people.id = season_memberships.person_id AND season_memberships.season_id = %d AND season_memberships.role = %d", self.id, SeasonMembership.roles[:dancer]))
+        .where("season_memberships.id IS NULL")
+  end
+
+  def add_director(person)
+    if studio.people.where(id: person.id).exists?
+      if person.season_memberships.where(season_id: self.id, role: :director).exists?
+        errors.add(:base, "Person is already a director in this season.")
+        return false
+      end
+    else
+      errors.add(:base, "Person must be a member of the studio to be added as a director.")
+      return false
+    end
+
+    person.season_memberships.create(role: :director, season: self)
   end
 
   private

--- a/app/models/season.rb
+++ b/app/models/season.rb
@@ -30,9 +30,7 @@ class Season < ApplicationRecord
   end
 
   def get_eligible_dancers
-    self.studio.get_dancers
-        .joins(sprintf("LEFT OUTER JOIN season_memberships ON people.id = season_memberships.person_id AND season_memberships.season_id = %d AND season_memberships.role = %d", self.id, SeasonMembership.roles[:dancer]))
-        .where("season_memberships.id IS NULL")
+    self.studio.get_dancers.where.not(id: self.get_dancers)
   end
 
   def add_director(person)

--- a/app/models/season_membership.rb
+++ b/app/models/season_membership.rb
@@ -1,0 +1,14 @@
+class SeasonMembership < ApplicationRecord
+  belongs_to :season
+  belongs_to :person
+
+  enum :role, {
+    director: 0,
+    instructor: 1,
+    choreographer: 2,
+    dancer: 3
+  }
+
+  validates :role, presence: true
+  validates :person, uniqueness: { scope: [ :season, :role ] }
+end

--- a/app/models/studio.rb
+++ b/app/models/studio.rb
@@ -16,6 +16,20 @@ class Studio < ApplicationRecord
     person.studio_memberships.create(role: :dancer, studio: self)
   end
 
+  def get_dancers
+    self.people.where("studio_memberships.role = ?", StudioMembership.roles[:dancer])
+  end
+
+  def add_director(person)
+    # Check if the person is already a director of this studio
+    if person.studio_memberships.where(studio_id: self.id, role: :director).exists?
+      errors.add(:base, "Person is already a director of this studio.")
+      return false
+    end
+
+    person.studio_memberships.create(role: :director, studio: self)
+  end
+
   def add_owner(person)
     # Check if the person is already an owner of this studio
     if person.studio_memberships.where(studio_id: self.id, role: :owner).exists?

--- a/app/models/studio_membership.rb
+++ b/app/models/studio_membership.rb
@@ -6,10 +6,11 @@ class StudioMembership < ApplicationRecord
     owner: 0,
     admin: 1,
     staff: 2,
-    instructor: 3,
-    choreographer: 4,
-    parent: 5,
-    dancer: 6
+    director: 3,
+    instructor: 4,
+    choreographer: 5,
+    parent: 6,
+    dancer: 7
   }
 
   validates :role, presence: true

--- a/app/views/seasons/select_dancer.html.erb
+++ b/app/views/seasons/select_dancer.html.erb
@@ -1,0 +1,24 @@
+<%#
+  Expects:
+    @season - current season
+    @studio - current studio (optional if @season.studio is available)
+    @dancers - people in studio not yet dancers in this season
+%>
+
+<h1 class="text-2xl font-bold mb-6">Add Dancer to <%= @season.name %></h1>
+
+<%= form_with url: add_dancer_season_path(@season), method: :post, local: true, class: "space-y-4" do |form| %>
+  <div class="form-control">
+    <%= form.label :person_id, "Select Dancer", class: "label" %>
+    <%= form.select :person_id,
+      options_from_collection_for_select(
+        @dancers, :id, :full_name
+      ),
+      { prompt: "Choose a dancer" },
+      class: "select select-bordered w-full" %>
+  </div>
+  <div class="flex gap-2 mt-4">
+    <%= form.submit "Add Dancer", class: "btn btn-primary w-full sm:w-auto" %>
+    <%= link_to "Cancel", season_path(@season), class: "btn btn-ghost" %>
+  </div>
+<% end %>

--- a/app/views/seasons/show.html.erb
+++ b/app/views/seasons/show.html.erb
@@ -31,13 +31,52 @@
   </div>
 </div>
 
-<div class="divider">Classes</div>
+<!-- name of each tab group should be unique -->
+<div class="tabs tabs-lift">
+  <label class="tab">
+    <input type="radio" name="my_tabs_4" checked="checked" />
+    <!-- Heroicons: academic-cap -->
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-4 me-2">
+      <path stroke-linecap="round" stroke-linejoin="round" d="M4.26 10.147a60.438 60.438 0 0 0-.491 6.347A48.62 48.62 0 0 1 12 20.904a48.62 48.62 0 0 1 8.232-4.41 60.46 60.46 0 0 0-.491-6.347m-15.482 0a50.636 50.636 0 0 0-2.658-.813A59.906 59.906 0 0 1 12 3.493a59.903 59.903 0 0 1 10.399 5.84c-.896.248-1.783.52-2.658.814m-15.482 0A50.717 50.717 0 0 1 12 13.489a50.702 50.702 0 0 1 7.74-3.342M6.75 15a.75.75 0 1 0 0-1.5.75.75 0 0 0 0 1.5Zm0 0v-3.675A55.378 55.378 0 0 1 12 8.443m-7.007 11.55A5.981 5.981 0 0 0 6.75 15.75v-1.5" />
+    </svg>
+    Classes
+  </label>
+  <div class="tab-content bg-base-100 border-base-300 p-6">
+    <div class="flex justify-between items-center mb-4">
+      <h2 class="text-2xl font-bold">Classes</h2>
+      <%= link_to "Add Class", "#", class: "btn btn-primary" %>
+    </div>
 
-<div class="flex justify-between items-center mb-4">
-  <h2 class="text-2xl font-bold">Classes</h2>
-  <%= link_to "Add Class", "#", class: "btn btn-primary" %>
-</div>
+    <div id="classes">
+      <p class="text-center text-gray-500 my-8">No classes have been added to this season yet.</p>
+    </div>
+  </div>
 
-<div id="classes">
-  <p class="text-center text-gray-500 my-8">No classes have been added to this season yet.</p>
+  <label class="tab">
+    <input type="radio" name="my_tabs_4" />
+    <!-- Heroicons: user-group -->
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-4 me-2">
+      <path stroke-linecap="round" stroke-linejoin="round" d="M18 18.72a9.094 9.094 0 0 0 3.741-.479 3 3 0 0 0-4.682-2.72m.94 3.198.001.031c0 .225-.012.447-.037.666A11.944 11.944 0 0 1 12 21c-2.17 0-4.207-.576-5.963-1.584A6.062 6.062 0 0 1 6 18.719m12 0a5.971 5.971 0 0 0-.941-3.197m0 0A5.995 5.995 0 0 0 12 12.75a5.995 5.995 0 0 0-5.058 2.772m0 0a3 3 0 0 0-4.681 2.72 8.986 8.986 0 0 0 3.74.477m.94-3.197a5.971 5.971 0 0 0-.94 3.197M15 6.75a3 3 0 1 1-6 0 3 3 0 0 1 6 0Zm6 3a2.25 2.25 0 1 1-4.5 0 2.25 2.25 0 0 1 4.5 0Zm-13.5 0a2.25 2.25 0 1 1-4.5 0 2.25 2.25 0 0 1 4.5 0Z" />
+    </svg>
+    Dancers
+  </label>
+  <div class="tab-content bg-base-100 border-base-300 p-6">
+    <div class="flex justify-between items-center mb-4">
+      <h2 class="text-2xl font-bold">Dancers</h2>
+      <%= link_to "Add Dancer", select_dancer_season_path(@season), class: "btn btn-primary" %>
+    </div>
+
+    <div id="dancers">
+      <% dancers = @season.get_dancers %>
+      <% if dancers.any? %>
+        <ul class="list-disc pl-6">
+          <% dancers.each do |dancer| %>
+            <li><%= dancer.full_name %></li>
+          <% end %>
+        </ul>
+      <% else %>
+        <p class="text-center text-gray-500 my-8">No dancers have been added to this season yet.</p>
+      <% end %>
+    </div>
+  </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,7 +21,12 @@ Rails.application.routes.draw do
       post "add_dancer"
     end
 
-    resources :seasons, shallow: true
+    resources :seasons, shallow: true do
+      member do
+        get "select_dancer"
+        post "add_dancer"
+      end
+    end
   end
 
   # Defines the root path route ("/")

--- a/db/migrate/20250824020632_create_season_memberships.rb
+++ b/db/migrate/20250824020632_create_season_memberships.rb
@@ -1,0 +1,12 @@
+class CreateSeasonMemberships < ActiveRecord::Migration[8.0]
+  def change
+    create_table :season_memberships do |t|
+      t.references :season, null: false, foreign_key: true
+      t.references :person, null: false, foreign_key: true
+      t.integer :role
+
+      t.timestamps
+    end
+    add_index :season_memberships, [ :season_id, :person_id, :role ], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_08_09_002633) do
+ActiveRecord::Schema[8.0].define(version: 2025_08_24_020632) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -19,6 +19,17 @@ ActiveRecord::Schema[8.0].define(version: 2025_08_09_002633) do
     t.string "last_name", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+  end
+
+  create_table "season_memberships", force: :cascade do |t|
+    t.bigint "season_id", null: false
+    t.bigint "person_id", null: false
+    t.integer "role"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["person_id"], name: "index_season_memberships_on_person_id"
+    t.index ["season_id", "person_id", "role"], name: "index_season_memberships_on_season_id_and_person_id_and_role", unique: true
+    t.index ["season_id"], name: "index_season_memberships_on_season_id"
   end
 
   create_table "seasons", force: :cascade do |t|
@@ -71,6 +82,8 @@ ActiveRecord::Schema[8.0].define(version: 2025_08_09_002633) do
     t.index ["email_address"], name: "index_users_on_email_address", unique: true
   end
 
+  add_foreign_key "season_memberships", "people"
+  add_foreign_key "season_memberships", "seasons"
   add_foreign_key "seasons", "studios"
   add_foreign_key "sessions", "users"
   add_foreign_key "studio_memberships", "people"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -13,6 +13,22 @@ User.find_or_create_by!(
   password_digest: BCrypt::Password.create("gNX$KqB3$hcLcYgN"),
 )
 
+def add_studio_membership(person, studio, role)
+  case role.to_sym
+  when :owner
+    studio.add_owner(person)
+  when :dancer
+    studio.add_dancer(person)
+  else
+    StudioMembership.find_or_create_by!(person: person, studio: studio, role: role)
+  end
+end
+
+def add_season_membership(person, season, role)
+  SeasonMembership.find_or_create_by!(person: person, season: season, role: role)
+end
+
+# Studios
 avanti = Studio.find_or_create_by!(
   name: "Avanti Dance Company",
   address_line1: "151 Kalmus Dr",
@@ -22,73 +38,48 @@ avanti = Studio.find_or_create_by!(
   zip_code: "92626"
 )
 
-Season.find_or_create_by!(
-  name: "Season 9",
-  start_year: 2023,
-  end_year: 2024,
-  studio: avanti
-)
+# Seasons
+seasons = {
+  "Season 9" => Season.find_or_create_by!(name: "Season 9", start_year: 2023, end_year: 2024, studio: avanti),
+  "Season 10" => Season.find_or_create_by!(name: "Season 10", start_year: 2024, end_year: 2025, studio: avanti),
+  "Season 11" => Season.find_or_create_by!(name: "Season 11", start_year: 2025, end_year: 2026, studio: avanti)
+}
 
-Season.find_or_create_by!(
-  name: "Season 10",
-  start_year: 2024,
-  end_year: 2025,
-  studio: avanti
-)
-
-Season.find_or_create_by!(
-  name: "Season 11",
-  start_year: 2025,
-  end_year: 2026,
-  studio: avanti
-)
-
+# People
 people_data = [
   {
     first_name: "Taryn",
     last_name: "Chavez",
-    studio_memberships: [ { studio: avanti, role: :owner } ]
+    studio_roles: [[:owner, avanti]],
+    season_roles: []
   },
   {
     first_name: "Ailah",
     last_name: "Medina",
-    studio_memberships: [ { studio: avanti, role: :dancer } ]
+    studio_roles: [[:dancer, avanti]],
+    season_roles: [[:dancer, "Season 9"], [:dancer, "Season 10"], [:dancer, "Season 11"]]
   },
   {
     first_name: "Aurelia",
     last_name: "Coker",
-    studio_memberships: [ { studio: avanti, role: :dancer } ]
+    studio_roles: [[:dancer, avanti]],
+    season_roles: [[:dancer, "Season 10"]]
   },
   {
     first_name: "Kylie Sophia",
     last_name: "Bartolome",
-    studio_memberships: [ { studio: avanti, role: :dancer } ]
+    studio_roles: [[:dancer, avanti]],
+    season_roles: [[:dancer, "Season 9"], [:dancer, "Season 10"], [:dancer, "Season 11"]]
   }
 ]
 
 people = {}
-
 people_data.each do |attrs|
-  person = Person.find_or_create_by!(
-    first_name: attrs[:first_name],
-    last_name: attrs[:last_name]
-  )
+  person = Person.find_or_create_by!(first_name: attrs[:first_name], last_name: attrs[:last_name])
   people[person.full_name] = person
-  attrs[:studio_memberships].each do |role_attrs|
-    studio = role_attrs[:studio]
-    role = role_attrs[:role].to_sym
-
-    case role
-    when :owner
-      studio.add_owner(person)
-    when :dancer
-      studio.add_dancer(person)
-    else
-      StudioMembership.find_or_create_by!(
-        person: person,
-        studio: studio,
-        role: role
-      )
-    end
+  attrs[:studio_roles].each { |role, studio| add_studio_membership(person, studio, role) }
+  attrs[:season_roles].each do |role, season_name|
+    season = seasons[season_name]
+    add_season_membership(person, season, role) if season
   end
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -50,26 +50,26 @@ people_data = [
   {
     first_name: "Taryn",
     last_name: "Chavez",
-    studio_roles: [[:owner, avanti]],
+    studio_roles: [ [ :owner, avanti ] ],
     season_roles: []
   },
   {
     first_name: "Ailah",
     last_name: "Medina",
-    studio_roles: [[:dancer, avanti]],
-    season_roles: [[:dancer, "Season 9"], [:dancer, "Season 10"], [:dancer, "Season 11"]]
+    studio_roles: [ [ :dancer, avanti ] ],
+    season_roles: [ [ :dancer, "Season 9" ], [ :dancer, "Season 10" ], [ :dancer, "Season 11" ] ]
   },
   {
     first_name: "Aurelia",
     last_name: "Coker",
-    studio_roles: [[:dancer, avanti]],
-    season_roles: [[:dancer, "Season 10"]]
+    studio_roles: [ [ :dancer, avanti ] ],
+    season_roles: [ [ :dancer, "Season 10" ] ]
   },
   {
     first_name: "Kylie Sophia",
     last_name: "Bartolome",
-    studio_roles: [[:dancer, avanti]],
-    season_roles: [[:dancer, "Season 9"], [:dancer, "Season 10"], [:dancer, "Season 11"]]
+    studio_roles: [ [ :dancer, avanti ] ],
+    season_roles: [ [ :dancer, "Season 9" ], [ :dancer, "Season 10" ], [ :dancer, "Season 11" ] ]
   }
 ]
 

--- a/test/factories/season_memberships.rb
+++ b/test/factories/season_memberships.rb
@@ -1,19 +1,11 @@
 FactoryBot.define do
-  factory :studio_membership do
+  factory :season_membership do
+    season
     person
-    studio
     role { :dancer }
 
-    trait :owner do
-      role { :owner }
-    end
-
-    trait :admin do
-      role { :admin }
-    end
-
-    trait :staff do
-      role { :staff }
+    trait :director do
+      role { :director }
     end
 
     trait :instructor do
@@ -22,10 +14,6 @@ FactoryBot.define do
 
     trait :choreographer do
       role { :choreographer }
-    end
-
-    trait :parent do
-      role { :parent }
     end
 
     trait :dancer do

--- a/test/models/season_membership_test.rb
+++ b/test/models/season_membership_test.rb
@@ -1,0 +1,57 @@
+require "test_helper"
+
+class SeasonMembershipTest < ActiveSupport::TestCase
+  def setup
+    @season_membership = build(:season_membership)
+  end
+
+  test "is valid with all required attributes" do
+    assert @season_membership.valid?
+  end
+
+  test "is invalid without person" do
+    @season_membership.person = nil
+
+    assert_not @season_membership.valid?
+    assert_includes @season_membership.errors[:person], "must exist"
+  end
+
+  test "is invalid without season" do
+    @season_membership.season = nil
+
+    assert_not @season_membership.valid?
+    assert_includes @season_membership.errors[:season], "must exist"
+  end
+
+  test "is invalid without role type" do
+    @season_membership.role = nil
+
+    assert_not @season_membership.valid?
+    assert_includes @season_membership.errors[:role], "can't be blank"
+  end
+
+  test "is invalid with duplicate role for person in same season" do
+    @season_membership.save!
+
+    duplicate = build(:season_membership, person: @season_membership.person, season: @season_membership.season, role: @season_membership.role)
+
+    assert_not duplicate.valid?
+    assert_includes duplicate.errors[:person], "has already been taken"
+  end
+
+  test "is valid with unique roles for person in same season" do
+    @season_membership.save!
+
+    unique_role = build(:season_membership, person: @season_membership.person, season: @season_membership.season, role: :choreographer)
+
+    assert unique_role.valid?
+  end
+
+  test "is valid with same role for person in different seasons" do
+    @season_membership.save!
+
+    different_season_role = build(:season_membership, person: @season_membership.person, season: create(:season), role: @season_membership.role)
+
+    assert different_season_role.valid?
+  end
+end

--- a/test/models/season_test.rb
+++ b/test/models/season_test.rb
@@ -57,4 +57,125 @@ class SeasonTest < ActiveSupport::TestCase
     @season.end_year = 2024
     assert_equal "2023 - 2024", @season.year
   end
+
+  test "add_dancer adds dancer role for person" do
+    @season.save!
+
+    person = create(:person)
+    @season.studio.add_dancer(person)
+
+    assert_difference -> { person.season_memberships.where(season: @season, role: :dancer).count }, 1 do
+      result = @season.add_dancer(person)
+
+      assert result.persisted?
+      assert_equal :dancer, result.role.to_sym
+      assert_equal @season, result.season
+    end
+  end
+
+  test "add_dancer does not add duplicate dancer role" do
+    @season.save!
+
+    person = create(:person)
+    @season.studio.add_dancer(person)
+    @season.add_dancer(person)
+
+    assert_no_difference -> { person.season_memberships.where(season: @season, role: :dancer).count } do
+      result = @season.add_dancer(person)
+
+      assert_not result
+      assert_includes @season.errors[:base], "Person is already a dancer in this season."
+    end
+  end
+
+  test "add_dancer does not add dancer role for person not in studio" do
+    @season.save!
+
+    person = create(:person)
+
+    assert_no_difference -> { person.season_memberships.where(season: @season, role: :dancer).count } do
+      result = @season.add_dancer(person)
+
+      assert_not result
+      assert_includes @season.errors[:base], "Person must be a member of the studio to be added as a dancer."
+    end
+  end
+
+  test "add_director adds director role for person" do
+    @season.save!
+
+    person = create(:person)
+    @season.studio.add_owner(person)
+
+    assert_difference -> { person.season_memberships.where(season: @season, role: :director).count }, 1 do
+      result = @season.add_director(person)
+
+      assert result.persisted?
+      assert_equal :director, result.role.to_sym
+      assert_equal @season, result.season
+    end
+  end
+
+  test "add_director does not add duplicate director role" do
+    @season.save!
+
+    person = create(:person)
+    @season.studio.add_director(person)
+    @season.add_director(person)
+
+    assert_no_difference -> { person.season_memberships.where(season: @season, role: :director).count } do
+      result = @season.add_director(person)
+
+      assert_not result
+      assert_includes @season.errors[:base], "Person is already a director in this season."
+    end
+  end
+
+  test "add_director does not add director role for person not in studio" do
+    @season.save!
+
+    person = create(:person)
+
+    assert_no_difference -> { person.season_memberships.where(season: @season, role: :director).count } do
+      result = @season.add_director(person)
+
+      assert_not result
+      assert_includes @season.errors[:base], "Person must be a member of the studio to be added as a director."
+    end
+  end
+
+  test "get_dancers returns only dancers for the season" do
+    @season.save!
+
+    dancer1 = create(:person)
+    dancer2 = create(:person)
+    director = create(:person)
+    @season.studio.add_dancer(dancer1)
+    @season.studio.add_dancer(dancer2)
+    @season.studio.add_director(director)
+    @season.add_dancer(dancer1)
+    @season.add_dancer(dancer2)
+    @season.add_director(director)
+
+    dancers = @season.get_dancers
+    assert_includes dancers, dancer1
+    assert_includes dancers, dancer2
+    assert_not_includes dancers, director
+    assert_equal 2, dancers.count
+  end
+
+  test "get_eligible_dancers returns studio dancers not already in season" do
+    @season.save!
+
+    eligible = create(:person)
+    ineligible = create(:person)
+    @season.studio.add_dancer(eligible)
+    @season.studio.add_dancer(ineligible)
+    @season.add_dancer(ineligible)
+
+    eligible_dancers = @season.get_eligible_dancers
+    assert_includes eligible_dancers, eligible
+    assert_not_includes eligible_dancers, ineligible
+    assert_equal 1, eligible_dancers.count
+  end
 end


### PR DESCRIPTION
This pull request introduces the concept of season memberships, allowing people (such as dancers and directors) to be associated with specific seasons in addition to studios. It adds models, controller actions, views, and supporting tests for managing dancers within a season, including the ability to add eligible dancers and display them in the UI. The changes also update the database schema and seed data to support these new relationships.

**Season Memberships and Associations**

- Added a new `SeasonMembership` model and migration to represent the association between a `Person` and a `Season` with a specific role (e.g., dancer, director). This includes validations for uniqueness and presence, and updates to the schema and seeds to support the new model. [[1]](diffhunk://#diff-4a7fc5d983a8fd54b595f12550326b5194392cfb3de0d9889dc22aac435bd8fcR1-R14) [[2]](diffhunk://#diff-b4851efde2b40962048db3e3da59d169500e6b3f3e12e77f4a14b74f7b2aa1f4R1-R12) [[3]](diffhunk://#diff-cbf8b25d6d853acf58fa9057841f407d29ffe90649c75cf9e3f51b2d6e3aa1d3R24-R34) [[4]](diffhunk://#diff-cbf8b25d6d853acf58fa9057841f407d29ffe90649c75cf9e3f51b2d6e3aa1d3R85-R86) [[5]](diffhunk://#diff-afb6f8bc3bae71b75743e00882a060863e2430cbe858ec9014e5956504dfc61cR4-R5) [[6]](diffhunk://#diff-09705bd8df4145db315c0a6746fe9f4af741e2d4d699912ba672cf22a83f56a9R4-R51) [[7]](diffhunk://#diff-c61a903a1201b0c7f076b0270377c20390c26f655ce63689d7d843296fcf63f3R16-R31) [[8]](diffhunk://#diff-c61a903a1201b0c7f076b0270377c20390c26f655ce63689d7d843296fcf63f3L25-R83)

- Updated the `Season` and `Person` models to establish associations through `season_memberships`, and added methods to manage and query dancers and directors for a season. [[1]](diffhunk://#diff-afb6f8bc3bae71b75743e00882a060863e2430cbe858ec9014e5956504dfc61cR4-R5) [[2]](diffhunk://#diff-09705bd8df4145db315c0a6746fe9f4af741e2d4d699912ba672cf22a83f56a9R4-R51)

**Controller and View Enhancements**

- Added `select_dancer` and `add_dancer` actions to the `SeasonsController`, with corresponding routes and a new view (`select_dancer.html.erb`) to facilitate adding eligible dancers to a season. [[1]](diffhunk://#diff-580f262fdd1edcda4816ec5e610732ebe8dba694baf6184bdd01311bda0afeadR50-R65) [[2]](diffhunk://#diff-959bc9abc46a55332bb64d5155a79323afa75a50ec1a2137ddd22d926f62c6c5L24-R29) [[3]](diffhunk://#diff-5bcd8994e86945bedf96fbecee59934056980f475567deec90f21abeefc8c9a5R1-R24)

- Enhanced the season show page to display a new "Dancers" tab, listing all dancers in the season and providing a button to add more. [[1]](diffhunk://#diff-68ff8097d030043dca888385a19e460273bab7c48d6f20496bd9f2a7779cd463L34-R44) [[2]](diffhunk://#diff-68ff8097d030043dca888385a19e460273bab7c48d6f20496bd9f2a7779cd463R53-R82)

**Studio Membership Role Adjustments**

- Updated the `StudioMembership` enum to add a `director` role and adjust role values for consistency with season memberships. Also added methods to manage and query dancers and directors in a studio. [[1]](diffhunk://#diff-b6d6d1e927b0506d7fbe43791d9d876f7cfc1fe814937594215c02124be20dc8L9-R13) [[2]](diffhunk://#diff-f9922cf72205415b7722f75e8a51520eb78198b60104198b1b2b3d11881942c2R19-R32)

**Testing and Factories**

- Added comprehensive controller tests for the new dancer management actions, as well as model tests and factories for `SeasonMembership`. [[1]](diffhunk://#diff-7ec36d40a994ca1150b12e4ce0c26b48580ac48b9e91d7be81bdf06e0bc02c74R169-R243) [[2]](diffhunk://#diff-249e79e13f44b9f0f4f0457d7738c7c33286aa32fcca6e02b38c7cefa8e2bcc1R1-R23) [[3]](diffhunk://#diff-229be2691d7be70766aa80140b05bd8b9403d79c387a8f8b8938ca70d4c99d4fR1-R57) [[4]](diffhunk://#diff-f72afb13d6778aa693756cb660f971226f7e512c94077f2eefb8d909cf53733eR6-R33)

These changes collectively enable fine-grained management of people and their roles within specific seasons, improving the flexibility and accuracy of the application's data model.